### PR TITLE
Refactor and simplify code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Multer Storage for AliYun OSS
+
 Dependencies [@ali-oss](https://github.com/ali-sdk/ali-oss)
-### Install
+
+## Install
+
 ```npm
 npm install --save multer-aliyun-oss
 ```
-### Usage
+
+## Usage
+
 ```js
 const multer = require('multer');
 const MAO = require('multer-aliyun-oss');
@@ -16,13 +21,14 @@ const upload = multer({
             accessKeyId: '<accessKeyId>',
             accessKeySecret: '<accessKeySecret>',
             bucket: '<bucket>',
-            path: ''
-        }
+        },
+        // to set path prefix for files, could be string or function
+        destination: ''
     })
 });
 ```
 
-### File information
+## File information
 
 Each file contains the following information:
 
@@ -38,26 +44,19 @@ Key | Description | Note
 `path` | The full path to the uploaded file | `DiskStorage`
 `buffer` | A `Buffer` of the entire file | `MemoryStorage`
 
-### Option
-#### config.path
+## Option
+
+### destination
 
 `String` or `Function`
 
 ```
-// Function ES6 Promise
-path ({ req, file }) {
-    return new Promise((resolve, reject) => {
-        resolve('images')
-    })
-}
-
-// Function ES7 async/await
-async path ({ req, file }) {
-    return 'images'
+// same signature as multer native
+destination (req, file, callback) {
+    callback(null, 'images')
 }
 ```
 
-### Author
-&copy; AngusYoung
+## Author
 
-<angusyoung@mrxcool.com>
+&copy; AngusYoung <angusyoung@mrxcool.com>

--- a/index.js
+++ b/index.js
@@ -48,10 +48,11 @@ class AliYunOssStorage {
             })
             .then(result => {
                 const { url, name } = result;
-                const path = name.substr(0, name.lastIndexOf('/'));
+                const lastSlashIndex = name.lastIndexOf('/');
+                const path = name.substr(0, lastSlashIndex);
                 cb(null, {
                     destination: path,
-                    filename: name.substr(name.lastIndexOf('/')),
+                    filename: name.substr(lastSlashIndex + 1),
                     path,
                     size
                 });

--- a/index.js
+++ b/index.js
@@ -3,84 +3,63 @@
  * @Description Multer storage for Aliyun OSS
  * @Since 2018/8/17
  */
-const OSS = require('ali-oss');
+const { promisify } = require('util');
+const Path = require('path');
 const crypto = require('crypto');
+const OSS = require('ali-oss');
 
+const ERROR_NO_CLIENT = 'oss client undefined';
 
-const ERROR_MESSAGE = 'oss client undefined'
-
-const getFilename = ({ req, file, ossPath }) => {
-    return new Promise((resolve, reject) => {
-        crypto.randomBytes(16, (err, raw) => {
-            err && reject(err)
-            let ext = '';
-            if (file.originalname.indexOf(".") > -1) {
-                ext = file.originalname.substr(file.originalname.lastIndexOf('.'));
-            }
-            let name = raw.toString('hex') + ext;
-            resolve(name)
-        });
-    })
-};
-
-const getPath = (path) => {
-    return function() {
-        return Promise.resolve(path)
-    }
+// keep same signature as multer native
+function getRandomFilename(req, file, cb) {
+  crypto.pseudoRandomBytes(16, function (err, raw) {
+    cb(err, err ? undefined : `${raw.toString('hex')}${Path.extname(file.originalname)}`);
+  });
 }
 
 class AliYunOssStorage {
-
-    constructor(opts) {
-        if (opts.config.path && typeof opts.config.path === 'string') {
-            this.getPath = getPath(opts.config.path)
-        } else if(opts.config.path && typeof opts.config.path === 'function') {
-            this.getPath = opts.config.path
-        } else {
-            this.getPath = getPath('')
-        }
-
-        this.client = new OSS(opts.config);
-        this.getFilename = opts.filename || getFilename;
+    constructor({ config, destination = '', filename = getRandomFilename }) {
+        this.client = new OSS(config);
+        this.getDestination = typeof destination === 'string' ? (req, file, cb) => cb(null, destination) : destination;
+        this.getFilename = filename;
     }
 
     _handleFile(req, file, cb) {
         if (!this.client) {
-            console.error(ERROR_MESSAGE);
-            return cb({ message: ERROR_MESSAGE });
+            return cb(new Error(ERROR_NO_CLIENT));
         }
-        let ossPath, filename, url, size;
-        this.getPath({ req, file })
-            .then(_ossPath => {
-                ossPath = _ossPath
-                return this.getFilename({ req, file })
-            })
-            .then(_filename => {
-                filename = _filename
-                return this.client.putStream(ossPath + '/' + filename, file.stream)
-            })
-            .then(({ url: _url, name }) => {
-                url = _url
-                return this.client.getObjectMeta(name)
-            })
-            .then(meta => {
-                size = (meta && meta.status && meta.res && meta.res.headers) ? meta.res.headers["content-length"] : null
-                return cb(null, {
-                    destination: url.substr(0, url.lastIndexOf('/')),
-                    filename,
-                    path: url,
+
+        const getDestination = promisify(this.getDestination);
+        const getFilename = promisify(this.getFilename);
+
+        let size = 0;
+
+        file.stream.on('data', chunk => {
+          size += Buffer.byteLength(chunk);
+        });
+
+        Promise.all([
+            getDestination(req, file),
+            getFilename(req, file)
+        ])
+            .then(([destination, filename]) => this.client.putStream(`${destination}/${filename}`, file.stream))
+            .then(result => {
+                const { url, name } = result;
+                const path = name.substr(0, url.lastIndexOf('/'));
+                cb(null, {
+                    destination: path,
+                    filename: name,
+                    path,
                     size
-                })
+                });
             })
-            .catch(err => {
-                return cb(err)
-            })
+            .catch(cb);
+
     }
 
     _removeFile(req, file, cb) {
         if (!this.client) {
-            console.error(ERROR_MESSAGE);
-            return cb({ message: ERROR_MESSAGE });
+            return cb(new Error(ERROR_NO_CLIENT));
         }
         this.client.delete(file.filename).then(
             result => {


### PR DESCRIPTION
1. Use native method of stream to calculate file size, instead of sending another request.
2. Change API `path` to outside of Aliyun `config`, and rename to `destination`, to align to native multer.
3. Change API `destination`'s signature to `(req, file, cb)`, to align to native multer.
4. Use `promisify` to simplify codes.